### PR TITLE
Make user.documents only return distinct document records

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,5 @@ class User < ApplicationRecord
   include Clearance::User
 
   has_many :permissions
-  has_many :documents, through: :permissions 
+  has_many :documents, -> { distinct }, through: :permissions
 end


### PR DESCRIPTION
Right now, user.documents will return one document record for each permission a user has on the doc (i.e. if they have read and write permission, it returns the same doc twice).

This fixes that